### PR TITLE
Add wt - git worktree manager CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "test@example.com"
+          git config --global user.name "Test User"
+
+      - name: Run tests with coverage
+        run: go test -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Check 100% coverage
+        run: |
+          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
+          echo "Total coverage: ${COVERAGE}%"
+          if [ "$(echo "$COVERAGE < 100" | bc)" -eq 1 ]; then
+            echo "Coverage is below 100%"
+            go tool cover -func=coverage.out
+            exit 1
+          fi
+          echo "Coverage is 100%"
+
+      - name: Build
+        run: go build -o wt .

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Binary
+wt
+
+# Coverage
+coverage.out

--- a/create.go
+++ b/create.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func create(name, hookPath string) error {
+	// Find git root
+	root, err := gitRoot()
+	if err != nil {
+		return err
+	}
+
+	// Check .worktrees directory exists
+	worktreesDir := filepath.Join(root, ".worktrees")
+	if _, err := os.Stat(worktreesDir); os.IsNotExist(err) {
+		return fmt.Errorf(".worktrees directory does not exist (create it first)")
+	}
+
+	worktreePath := filepath.Join(worktreesDir, name)
+
+	// Create worktree with new branch
+	fmt.Printf("Creating worktree at .worktrees/%s with branch %s\n", name, name)
+	if err := gitCmd(root, "worktree", "add", worktreePath, "-b", name); err != nil {
+		return fmt.Errorf("failed to create worktree: %w", err)
+	}
+
+	// Run hook if it exists
+	hookFullPath := filepath.Join(root, hookPath)
+	if _, err := os.Stat(hookFullPath); err == nil {
+		fmt.Printf("Running hook: %s\n", hookPath)
+		if err := runHook(hookFullPath, worktreePath); err != nil {
+			return fmt.Errorf("hook failed: %w", err)
+		}
+	}
+
+	fmt.Printf("Done! Worktree ready at .worktrees/%s\n", name)
+	return nil
+}
+
+func runHook(hookPath, worktreePath string) error {
+	cmd := exec.Command(hookPath)
+	cmd.Dir = worktreePath
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/create_test.go
+++ b/create_test.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCreate(t *testing.T) {
+	// Save original functions and restore after test
+	origGitRoot := gitRootFn
+	origGitCmd := gitCmdFn
+	defer func() {
+		gitRootFn = origGitRoot
+		gitCmdFn = origGitCmd
+	}()
+
+	t.Run("git root error", func(t *testing.T) {
+		gitRootFn = func() (string, error) {
+			return "", errors.New("not in a git repository")
+		}
+
+		err := create("test-branch", ".worktree-hook")
+		if err == nil || err.Error() != "not in a git repository" {
+			t.Errorf("create() error = %v, want 'not in a git repository'", err)
+		}
+	})
+
+	t.Run("worktrees dir does not exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		gitRootFn = func() (string, error) {
+			return tmpDir, nil
+		}
+
+		err := create("test-branch", ".worktree-hook")
+		if err == nil || !strings.Contains(err.Error(), ".worktrees directory does not exist") {
+			t.Errorf("create() error = %v, want error about .worktrees not existing", err)
+		}
+	})
+
+	t.Run("git worktree add fails", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		os.MkdirAll(filepath.Join(tmpDir, ".worktrees"), 0755)
+
+		gitRootFn = func() (string, error) {
+			return tmpDir, nil
+		}
+		gitCmdFn = func(dir string, args ...string) error {
+			if len(args) > 0 && args[0] == "worktree" {
+				return errors.New("git worktree failed")
+			}
+			return nil
+		}
+
+		err := create("test-branch", ".worktree-hook")
+		if err == nil || !strings.Contains(err.Error(), "failed to create worktree") {
+			t.Errorf("create() error = %v, want error about failed to create worktree", err)
+		}
+	})
+
+	t.Run("success without hook", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		os.MkdirAll(filepath.Join(tmpDir, ".worktrees"), 0755)
+
+		gitRootFn = func() (string, error) {
+			return tmpDir, nil
+		}
+		gitCmdFn = func(dir string, args ...string) error {
+			return nil
+		}
+
+		err := create("test-branch", ".worktree-hook")
+		if err != nil {
+			t.Errorf("create() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("success with hook", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		worktreesDir := filepath.Join(tmpDir, ".worktrees")
+		os.MkdirAll(worktreesDir, 0755)
+
+		// Create a hook script that succeeds
+		hookPath := filepath.Join(tmpDir, ".worktree-hook")
+		err := os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 0\n"), 0755)
+		if err != nil {
+			t.Fatalf("failed to create hook: %v", err)
+		}
+
+		// Create the worktree directory (simulating git worktree add)
+		worktreePath := filepath.Join(worktreesDir, "test-branch")
+
+		gitRootFn = func() (string, error) {
+			return tmpDir, nil
+		}
+		gitCmdFn = func(dir string, args ...string) error {
+			// Simulate git worktree add by creating the directory
+			if len(args) > 0 && args[0] == "worktree" {
+				os.MkdirAll(worktreePath, 0755)
+			}
+			return nil
+		}
+
+		err = create("test-branch", ".worktree-hook")
+		if err != nil {
+			t.Errorf("create() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("hook fails", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		worktreesDir := filepath.Join(tmpDir, ".worktrees")
+		os.MkdirAll(worktreesDir, 0755)
+
+		// Create a hook script that fails
+		hookPath := filepath.Join(tmpDir, ".worktree-hook")
+		err := os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 1\n"), 0755)
+		if err != nil {
+			t.Fatalf("failed to create hook: %v", err)
+		}
+
+		// Create the worktree directory
+		worktreePath := filepath.Join(worktreesDir, "test-branch")
+
+		gitRootFn = func() (string, error) {
+			return tmpDir, nil
+		}
+		gitCmdFn = func(dir string, args ...string) error {
+			if len(args) > 0 && args[0] == "worktree" {
+				os.MkdirAll(worktreePath, 0755)
+			}
+			return nil
+		}
+
+		err = create("test-branch", ".worktree-hook")
+		if err == nil || !strings.Contains(err.Error(), "hook failed") {
+			t.Errorf("create() error = %v, want error about hook failed", err)
+		}
+	})
+
+	t.Run("custom hook path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		worktreesDir := filepath.Join(tmpDir, ".worktrees")
+		os.MkdirAll(worktreesDir, 0755)
+
+		// Create a custom hook script
+		hookPath := filepath.Join(tmpDir, "custom-hook.sh")
+		err := os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 0\n"), 0755)
+		if err != nil {
+			t.Fatalf("failed to create hook: %v", err)
+		}
+
+		worktreePath := filepath.Join(worktreesDir, "test-branch")
+
+		gitRootFn = func() (string, error) {
+			return tmpDir, nil
+		}
+		gitCmdFn = func(dir string, args ...string) error {
+			if len(args) > 0 && args[0] == "worktree" {
+				os.MkdirAll(worktreePath, 0755)
+			}
+			return nil
+		}
+
+		err = create("test-branch", "custom-hook.sh")
+		if err != nil {
+			t.Errorf("create() unexpected error: %v", err)
+		}
+	})
+}
+
+func TestRunHook(t *testing.T) {
+	t.Run("successful hook", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		hookPath := filepath.Join(tmpDir, "hook.sh")
+		err := os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 0\n"), 0755)
+		if err != nil {
+			t.Fatalf("failed to create hook: %v", err)
+		}
+
+		err = runHook(hookPath, tmpDir)
+		if err != nil {
+			t.Errorf("runHook() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("failing hook", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		hookPath := filepath.Join(tmpDir, "hook.sh")
+		err := os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 42\n"), 0755)
+		if err != nil {
+			t.Fatalf("failed to create hook: %v", err)
+		}
+
+		err = runHook(hookPath, tmpDir)
+		if err == nil {
+			t.Error("runHook() expected error for failing hook")
+		}
+	})
+
+	t.Run("non-existent hook", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		err := runHook(filepath.Join(tmpDir, "nonexistent.sh"), tmpDir)
+		if err == nil {
+			t.Error("runHook() expected error for non-existent hook")
+		}
+	})
+}

--- a/git.go
+++ b/git.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Function variables for testing
+var (
+	gitRootFn = defaultGitRoot
+	gitCmdFn  = defaultGitCmd
+)
+
+func gitRoot() (string, error) {
+	return gitRootFn()
+}
+
+func gitCmd(dir string, args ...string) error {
+	return gitCmdFn(dir, args...)
+}
+
+func defaultGitRoot() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("not in a git repository")
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func defaultGitCmd(dir string, args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/git_test.go
+++ b/git_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestGitRoot(t *testing.T) {
+	// Save original function and restore after test
+	origGitRoot := gitRootFn
+	defer func() {
+		gitRootFn = origGitRoot
+	}()
+
+	t.Run("delegates to gitRootFn", func(t *testing.T) {
+		called := false
+		gitRootFn = func() (string, error) {
+			called = true
+			return "/test/path", nil
+		}
+
+		result, err := gitRoot()
+		if !called {
+			t.Error("gitRoot() did not call gitRootFn")
+		}
+		if err != nil {
+			t.Errorf("gitRoot() unexpected error: %v", err)
+		}
+		if result != "/test/path" {
+			t.Errorf("gitRoot() = %q, want %q", result, "/test/path")
+		}
+	})
+}
+
+func TestGitCmd(t *testing.T) {
+	// Save original function and restore after test
+	origGitCmd := gitCmdFn
+	defer func() {
+		gitCmdFn = origGitCmd
+	}()
+
+	t.Run("delegates to gitCmdFn", func(t *testing.T) {
+		var capturedDir string
+		var capturedArgs []string
+		gitCmdFn = func(dir string, args ...string) error {
+			capturedDir = dir
+			capturedArgs = args
+			return nil
+		}
+
+		err := gitCmd("/test/dir", "status", "-s")
+		if err != nil {
+			t.Errorf("gitCmd() unexpected error: %v", err)
+		}
+		if capturedDir != "/test/dir" {
+			t.Errorf("gitCmd() dir = %q, want %q", capturedDir, "/test/dir")
+		}
+		if len(capturedArgs) != 2 || capturedArgs[0] != "status" || capturedArgs[1] != "-s" {
+			t.Errorf("gitCmd() args = %v, want [status -s]", capturedArgs)
+		}
+	})
+}
+
+func TestDefaultGitRoot(t *testing.T) {
+	t.Run("not in git repo", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		// Change to temp dir that's not a git repo
+		origDir, _ := os.Getwd()
+		os.Chdir(tmpDir)
+		defer os.Chdir(origDir)
+
+		_, err := defaultGitRoot()
+		if err == nil {
+			t.Error("defaultGitRoot() expected error when not in git repo")
+		}
+		if err.Error() != "not in a git repository" {
+			t.Errorf("defaultGitRoot() error = %q, want %q", err.Error(), "not in a git repository")
+		}
+	})
+
+	t.Run("in git repo", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Initialize a git repo
+		cmd := exec.Command("git", "init")
+		cmd.Dir = tmpDir
+		if err := cmd.Run(); err != nil {
+			t.Skipf("git init failed: %v", err)
+		}
+
+		// Change to the git repo
+		origDir, _ := os.Getwd()
+		os.Chdir(tmpDir)
+		defer os.Chdir(origDir)
+
+		root, err := defaultGitRoot()
+		if err != nil {
+			t.Errorf("defaultGitRoot() unexpected error: %v", err)
+		}
+
+		// The root should be the tmpDir (accounting for symlinks)
+		expectedRoot, _ := filepath.EvalSymlinks(tmpDir)
+		actualRoot, _ := filepath.EvalSymlinks(root)
+		if actualRoot != expectedRoot {
+			t.Errorf("defaultGitRoot() = %q, want %q", actualRoot, expectedRoot)
+		}
+	})
+}
+
+func TestDefaultGitCmd(t *testing.T) {
+	t.Run("successful command", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Initialize a git repo
+		initCmd := exec.Command("git", "init")
+		initCmd.Dir = tmpDir
+		if err := initCmd.Run(); err != nil {
+			t.Skipf("git init failed: %v", err)
+		}
+
+		// Run a simple git command
+		err := defaultGitCmd(tmpDir, "status")
+		if err != nil {
+			t.Errorf("defaultGitCmd() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("failing command", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Run a git command that should fail (not a git repo, invalid command)
+		err := defaultGitCmd(tmpDir, "invalid-command-xyz")
+		if err == nil {
+			t.Error("defaultGitCmd() expected error for invalid command")
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module wt
+
+go 1.24.5

--- a/main.go
+++ b/main.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+const defaultHook = ".worktree-hook"
+
+// Sentinel errors for testing
+var (
+	errShowHelp     = errors.New("show help")
+	errShowHelpFail = errors.New("show help (error)")
+)
+
+// exitFn is the exit function, replaceable for testing
+var exitFn = os.Exit
+
+func usageText() string {
+	return `Usage: wt [options] <name>
+       wt create [options] <name>
+       wt remove <name>
+
+Commands:
+  create    Create a new worktree with branch (default if no command given)
+  remove    Remove a worktree and its branch
+
+Options:
+  --hook <path>    Custom hook script to run after create (default: .worktree-hook)
+  -h, --help       Show this help message
+
+Examples:
+  wt my-feature              Create worktree for 'my-feature' branch
+  wt create my-feature       Same as above
+  wt --hook setup.sh feat    Create worktree, run setup.sh as hook
+  wt remove my-feature       Remove worktree and branch
+`
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprint(w, usageText())
+}
+
+// parseArgs parses command line arguments and returns (command, name, hookPath, error)
+func parseArgs(args []string) (cmd string, name string, hookPath string, err error) {
+	if len(args) == 0 {
+		return "", "", "", errShowHelpFail
+	}
+
+	// Check for help flag anywhere
+	for _, arg := range args {
+		if arg == "-h" || arg == "--help" {
+			return "", "", "", errShowHelp
+		}
+	}
+
+	// Default values
+	cmd = "create"
+	hookPath = defaultHook
+
+	i := 0
+
+	// Check if first arg is a command
+	if len(args) > 0 {
+		switch args[0] {
+		case "create":
+			cmd = "create"
+			i++
+		case "remove":
+			cmd = "remove"
+			i++
+		}
+	}
+
+	// Parse flags
+	for i < len(args) {
+		if args[i] == "--hook" {
+			if i+1 >= len(args) {
+				return "", "", "", fmt.Errorf("--hook requires a path argument")
+			}
+			hookPath = args[i+1]
+			i += 2
+		} else if len(args[i]) > 0 && args[i][0] == '-' {
+			return "", "", "", fmt.Errorf("unknown flag %s", args[i])
+		} else {
+			break
+		}
+	}
+
+	// Remaining arg should be the name
+	if i >= len(args) {
+		return "", "", "", fmt.Errorf("branch name required")
+	}
+
+	name = args[i]
+
+	// Validate no extra args
+	if i+1 < len(args) {
+		return "", "", "", fmt.Errorf("unexpected argument: %s", args[i+1])
+	}
+
+	return cmd, name, hookPath, nil
+}
+
+// run executes the CLI with the given arguments
+func run(args []string) error {
+	cmd, name, hookPath, err := parseArgs(args)
+	if err != nil {
+		return err
+	}
+
+	// parseArgs guarantees cmd is "create" or "remove"
+	if cmd == "remove" {
+		return remove(name)
+	}
+	return create(name, hookPath)
+}
+
+func main() {
+	err := run(os.Args[1:])
+	if err != nil {
+		if errors.Is(err, errShowHelp) {
+			printUsage(os.Stdout)
+			exitFn(0)
+			return
+		}
+		if errors.Is(err, errShowHelpFail) {
+			printUsage(os.Stderr)
+			exitFn(1)
+			return
+		}
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		exitFn(1)
+		return
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestUsageText(t *testing.T) {
+	text := usageText()
+	if len(text) == 0 {
+		t.Error("usageText() returned empty string")
+	}
+	// Verify key content is present
+	if !bytes.Contains([]byte(text), []byte("wt [options] <name>")) {
+		t.Error("usageText() missing usage line")
+	}
+	if !bytes.Contains([]byte(text), []byte("--hook")) {
+		t.Error("usageText() missing --hook option")
+	}
+}
+
+func TestPrintUsage(t *testing.T) {
+	var buf bytes.Buffer
+	printUsage(&buf)
+	if buf.Len() == 0 {
+		t.Error("printUsage() wrote nothing")
+	}
+	if buf.String() != usageText() {
+		t.Error("printUsage() output doesn't match usageText()")
+	}
+}
+
+func TestParseArgs(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantCmd    string
+		wantName   string
+		wantHook   string
+		wantErr    error
+		wantErrMsg string
+	}{
+		{
+			name:    "no args",
+			args:    []string{},
+			wantErr: errShowHelpFail,
+		},
+		{
+			name:    "help flag -h",
+			args:    []string{"-h"},
+			wantErr: errShowHelp,
+		},
+		{
+			name:    "help flag --help",
+			args:    []string{"--help"},
+			wantErr: errShowHelp,
+		},
+		{
+			name:    "help flag in middle",
+			args:    []string{"create", "--help", "foo"},
+			wantErr: errShowHelp,
+		},
+		{
+			name:     "simple name (default create)",
+			args:     []string{"my-feature"},
+			wantCmd:  "create",
+			wantName: "my-feature",
+			wantHook: defaultHook,
+		},
+		{
+			name:     "explicit create",
+			args:     []string{"create", "my-feature"},
+			wantCmd:  "create",
+			wantName: "my-feature",
+			wantHook: defaultHook,
+		},
+		{
+			name:     "remove command",
+			args:     []string{"remove", "my-feature"},
+			wantCmd:  "remove",
+			wantName: "my-feature",
+			wantHook: defaultHook,
+		},
+		{
+			name:     "create with hook",
+			args:     []string{"--hook", "setup.sh", "my-feature"},
+			wantCmd:  "create",
+			wantName: "my-feature",
+			wantHook: "setup.sh",
+		},
+		{
+			name:     "create explicit with hook",
+			args:     []string{"create", "--hook", "setup.sh", "my-feature"},
+			wantCmd:  "create",
+			wantName: "my-feature",
+			wantHook: "setup.sh",
+		},
+		{
+			name:       "hook without path",
+			args:       []string{"--hook"},
+			wantErrMsg: "--hook requires a path argument",
+		},
+		{
+			name:       "unknown flag",
+			args:       []string{"--unknown", "foo"},
+			wantErrMsg: "unknown flag --unknown",
+		},
+		{
+			name:       "unknown short flag",
+			args:       []string{"-x", "foo"},
+			wantErrMsg: "unknown flag -x",
+		},
+		{
+			name:       "create without name",
+			args:       []string{"create"},
+			wantErrMsg: "branch name required",
+		},
+		{
+			name:       "remove without name",
+			args:       []string{"remove"},
+			wantErrMsg: "branch name required",
+		},
+		{
+			name:       "extra argument",
+			args:       []string{"create", "foo", "bar"},
+			wantErrMsg: "unexpected argument: bar",
+		},
+		{
+			name:       "hook at end without value",
+			args:       []string{"create", "--hook"},
+			wantErrMsg: "--hook requires a path argument",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, name, hook, err := parseArgs(tt.args)
+
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("parseArgs() error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+
+			if tt.wantErrMsg != "" {
+				if err == nil {
+					t.Errorf("parseArgs() error = nil, want error containing %q", tt.wantErrMsg)
+					return
+				}
+				if err.Error() != tt.wantErrMsg {
+					t.Errorf("parseArgs() error = %q, want %q", err.Error(), tt.wantErrMsg)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("parseArgs() unexpected error: %v", err)
+				return
+			}
+
+			if cmd != tt.wantCmd {
+				t.Errorf("parseArgs() cmd = %q, want %q", cmd, tt.wantCmd)
+			}
+			if name != tt.wantName {
+				t.Errorf("parseArgs() name = %q, want %q", name, tt.wantName)
+			}
+			if hook != tt.wantHook {
+				t.Errorf("parseArgs() hook = %q, want %q", hook, tt.wantHook)
+			}
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	// Save original functions and restore after test
+	origGitRoot := gitRootFn
+	origGitCmd := gitCmdFn
+	defer func() {
+		gitRootFn = origGitRoot
+		gitCmdFn = origGitCmd
+	}()
+
+	t.Run("parse error propagates", func(t *testing.T) {
+		err := run([]string{})
+		if !errors.Is(err, errShowHelpFail) {
+			t.Errorf("run() error = %v, want %v", err, errShowHelpFail)
+		}
+	})
+
+	t.Run("help error propagates", func(t *testing.T) {
+		err := run([]string{"--help"})
+		if !errors.Is(err, errShowHelp) {
+			t.Errorf("run() error = %v, want %v", err, errShowHelp)
+		}
+	})
+
+	t.Run("create command calls create", func(t *testing.T) {
+		gitRootFn = func() (string, error) {
+			return "", errors.New("mock: not in git repo")
+		}
+
+		err := run([]string{"my-feature"})
+		if err == nil || err.Error() != "mock: not in git repo" {
+			t.Errorf("run() error = %v, want 'mock: not in git repo'", err)
+		}
+	})
+
+	t.Run("remove command calls remove", func(t *testing.T) {
+		gitRootFn = func() (string, error) {
+			return "", errors.New("mock: not in git repo for remove")
+		}
+
+		err := run([]string{"remove", "my-feature"})
+		if err == nil || err.Error() != "mock: not in git repo for remove" {
+			t.Errorf("run() error = %v, want 'mock: not in git repo for remove'", err)
+		}
+	})
+}
+
+// TestMainFunc tests the main() function by mocking exitFn and os.Args
+func TestMainFunc(t *testing.T) {
+	// Save and restore original values
+	origArgs := os.Args
+	origExit := exitFn
+	origGitRoot := gitRootFn
+	defer func() {
+		os.Args = origArgs
+		exitFn = origExit
+		gitRootFn = origGitRoot
+	}()
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantExit int
+	}{
+		{
+			name:     "no args",
+			args:     []string{"wt"},
+			wantExit: 1,
+		},
+		{
+			name:     "help flag",
+			args:     []string{"wt", "--help"},
+			wantExit: 0,
+		},
+		{
+			name:     "help flag -h",
+			args:     []string{"wt", "-h"},
+			wantExit: 0,
+		},
+		{
+			name:     "error from run",
+			args:     []string{"wt", "test-branch"},
+			wantExit: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var exitCode int
+			exitFn = func(code int) {
+				exitCode = code
+			}
+
+			// Mock gitRoot to return an error (not in git repo)
+			gitRootFn = func() (string, error) {
+				return "", errors.New("not in a git repository")
+			}
+
+			os.Args = tt.args
+			main()
+
+			if exitCode != tt.wantExit {
+				t.Errorf("main() exit code = %d, want %d", exitCode, tt.wantExit)
+			}
+		})
+	}
+}
+
+// TestMainSuccess tests main() when run() succeeds
+func TestMainSuccess(t *testing.T) {
+	origArgs := os.Args
+	origExit := exitFn
+	origGitRoot := gitRootFn
+	origGitCmd := gitCmdFn
+	defer func() {
+		os.Args = origArgs
+		exitFn = origExit
+		gitRootFn = origGitRoot
+		gitCmdFn = origGitCmd
+	}()
+
+	// Create temp dir with .worktrees
+	tmpDir := t.TempDir()
+	os.MkdirAll(tmpDir+"/.worktrees", 0755)
+
+	exitCalled := false
+	exitFn = func(code int) {
+		exitCalled = true
+	}
+
+	gitRootFn = func() (string, error) {
+		return tmpDir, nil
+	}
+	gitCmdFn = func(dir string, args ...string) error {
+		return nil
+	}
+
+	os.Args = []string{"wt", "test-branch"}
+	main()
+
+	if exitCalled {
+		t.Error("main() should not call exit on success")
+	}
+}

--- a/remove.go
+++ b/remove.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+func remove(name string) error {
+	// Find git root
+	root, err := gitRoot()
+	if err != nil {
+		return err
+	}
+
+	worktreePath := filepath.Join(root, ".worktrees", name)
+
+	// Remove worktree
+	fmt.Printf("Removing worktree .worktrees/%s\n", name)
+	if err := gitCmd(root, "worktree", "remove", worktreePath); err != nil {
+		return fmt.Errorf("failed to remove worktree: %w", err)
+	}
+
+	// Delete branch
+	fmt.Printf("Deleting branch %s\n", name)
+	if err := gitCmd(root, "branch", "-D", name); err != nil {
+		return fmt.Errorf("failed to delete branch: %w", err)
+	}
+
+	fmt.Printf("Done! Worktree and branch removed\n")
+	return nil
+}

--- a/remove_test.go
+++ b/remove_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRemove(t *testing.T) {
+	// Save original functions and restore after test
+	origGitRoot := gitRootFn
+	origGitCmd := gitCmdFn
+	defer func() {
+		gitRootFn = origGitRoot
+		gitCmdFn = origGitCmd
+	}()
+
+	t.Run("git root error", func(t *testing.T) {
+		gitRootFn = func() (string, error) {
+			return "", errors.New("not in a git repository")
+		}
+
+		err := remove("test-branch")
+		if err == nil || err.Error() != "not in a git repository" {
+			t.Errorf("remove() error = %v, want 'not in a git repository'", err)
+		}
+	})
+
+	t.Run("worktree remove fails", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		gitRootFn = func() (string, error) {
+			return tmpDir, nil
+		}
+		gitCmdFn = func(dir string, args ...string) error {
+			if len(args) > 0 && args[0] == "worktree" && args[1] == "remove" {
+				return errors.New("worktree remove failed")
+			}
+			return nil
+		}
+
+		err := remove("test-branch")
+		if err == nil || !strings.Contains(err.Error(), "failed to remove worktree") {
+			t.Errorf("remove() error = %v, want error about failed to remove worktree", err)
+		}
+	})
+
+	t.Run("branch delete fails", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		gitRootFn = func() (string, error) {
+			return tmpDir, nil
+		}
+		gitCmdFn = func(dir string, args ...string) error {
+			if len(args) > 0 && args[0] == "branch" && args[1] == "-D" {
+				return errors.New("branch delete failed")
+			}
+			return nil
+		}
+
+		err := remove("test-branch")
+		if err == nil || !strings.Contains(err.Error(), "failed to delete branch") {
+			t.Errorf("remove() error = %v, want error about failed to delete branch", err)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		gitRootFn = func() (string, error) {
+			return tmpDir, nil
+		}
+		gitCmdFn = func(dir string, args ...string) error {
+			return nil
+		}
+
+		err := remove("test-branch")
+		if err != nil {
+			t.Errorf("remove() unexpected error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Go CLI tool for managing git worktrees with repo-specific hooks
- `wt <name>` creates a worktree at `.worktrees/<name>` with a new branch
- `wt remove <name>` removes the worktree and deletes the branch
- Supports custom hooks via `--hook <path>` (defaults to `.worktree-hook`)
- Includes comprehensive tests with 100% coverage
- GitHub Actions CI that enforces 100% coverage

## Test plan
- [x] All tests pass locally: `go test ./...`
- [x] Coverage verified at 100%: `go test -cover ./...`
- [ ] CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)