### PR TITLE
Add GoReleaser for binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,31 @@
+version: 2
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <tag>"
+    echo "Example: $0 v0.1.0"
+    exit 1
+fi
+
+TAG="$1"
+
+if [[ ! "$TAG" =~ ^v[0-9] ]]; then
+    echo "Error: Tag must start with 'v' followed by a number (e.g., v0.1.0)"
+    exit 1
+fi
+
+echo "Creating tag $TAG..."
+git tag "$TAG"
+
+echo "Pushing tag to origin..."
+git push origin "$TAG"
+
+echo "Done! The release workflow will now build and publish binaries."
+echo "Watch progress at: https://github.com/bsamek/wt/actions"


### PR DESCRIPTION
## Summary
- Add `.goreleaser.yaml` to build binaries for Linux/macOS/Windows (amd64 + arm64)
- Add release workflow that triggers on version tags (e.g., `v0.1.0`)
- Add `scripts/release.sh` helper script

## Usage
After merging, create a release with:
```bash
./scripts/release.sh v0.1.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)