### PR TITLE
Add pre-commit hook for tests and coverage

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+GIT_DIR="$(cd "$REPO_ROOT" && git rev-parse --git-dir)"
+
+mkdir -p "$GIT_DIR/hooks"
+ln -sf "$SCRIPT_DIR/pre-commit" "$GIT_DIR/hooks/pre-commit"
+echo "Pre-commit hook installed"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+echo "Running tests with coverage..."
+go test -coverprofile=coverage.out -covermode=atomic ./...
+
+COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
+
+if [ "$(echo "$COVERAGE < 100" | bc)" -eq 1 ]; then
+    echo "Coverage is ${COVERAGE}%, but 100% is required"
+    go tool cover -func=coverage.out
+    rm -f coverage.out
+    exit 1
+fi
+
+echo "Coverage: ${COVERAGE}%"
+rm -f coverage.out


### PR DESCRIPTION
## Summary
- Add shareable pre-commit hook that runs tests with coverage enforcement
- Hook mirrors the GHA workflow (100% coverage requirement)
- Include install script that works with both regular repos and worktrees

## Test plan
- [x] Run `./scripts/install-hooks.sh` to install the hook
- [x] Verify tests pass with 100% coverage
- [ ] Make a commit to verify hook runs and allows commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)