### PR TITLE
Add gha subcommand to monitor GitHub Actions status

### DIFF
--- a/gha.go
+++ b/gha.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Function variables for testing (following git.go pattern)
+var (
+	ghPRViewFn = defaultGhPRView
+	sleepFn    = time.Sleep
+)
+
+// Default polling configuration
+const (
+	defaultPollInterval = 30 * time.Second
+	defaultTimeout      = 60 * time.Minute
+)
+
+// PRStatus represents the GitHub PR status response
+type PRStatus struct {
+	Number            int           `json:"number"`
+	State             string        `json:"state"`
+	StatusCheckRollup []CheckStatus `json:"statusCheckRollup"`
+}
+
+// CheckStatus represents a single CI check
+type CheckStatus struct {
+	Name       string `json:"name"`
+	Status     string `json:"status"`     // QUEUED, IN_PROGRESS, COMPLETED
+	Conclusion string `json:"conclusion"` // SUCCESS, FAILURE, CANCELLED, etc.
+}
+
+// CheckResult represents the final outcome
+type CheckResult int
+
+const (
+	CheckResultPending CheckResult = iota
+	CheckResultSuccess
+	CheckResultFailure
+)
+
+func gha() error {
+	startTime := time.Now()
+
+	fmt.Println("Monitoring GitHub Actions for current branch's PR...")
+
+	for {
+		// Check timeout
+		if time.Since(startTime) > defaultTimeout {
+			return fmt.Errorf("timeout: checks did not complete within %v", defaultTimeout)
+		}
+
+		// Get PR status
+		status, err := ghPRViewFn()
+		if err != nil {
+			return err
+		}
+
+		// Analyze check results
+		result, summary := analyzeChecks(status.StatusCheckRollup)
+
+		// Print status update
+		fmt.Printf("\r%s", summary)
+
+		switch result {
+		case CheckResultSuccess:
+			fmt.Println("\nAll checks passed!")
+			return nil
+		case CheckResultFailure:
+			fmt.Println("\nSome checks failed!")
+			printCheckDetails(status.StatusCheckRollup)
+			return fmt.Errorf("checks failed")
+		case CheckResultPending:
+			// Continue polling
+			sleepFn(defaultPollInterval)
+		}
+	}
+}
+
+func defaultGhPRView() (*PRStatus, error) {
+	cmd := exec.Command("gh", "pr", "view", "--json", "number,state,statusCheckRollup")
+	out, err := cmd.Output()
+	if err != nil {
+		// Check if it's because there's no PR
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			stderr := string(exitErr.Stderr)
+			if strings.Contains(stderr, "no pull request") || strings.Contains(stderr, "no pull requests") {
+				return nil, fmt.Errorf("no PR found for current branch")
+			}
+		}
+		return nil, fmt.Errorf("failed to get PR status: %w", err)
+	}
+
+	var status PRStatus
+	if err := json.Unmarshal(out, &status); err != nil {
+		return nil, fmt.Errorf("failed to parse PR status: %w", err)
+	}
+
+	return &status, nil
+}
+
+func analyzeChecks(checks []CheckStatus) (CheckResult, string) {
+	if len(checks) == 0 {
+		return CheckResultPending, "No checks found yet..."
+	}
+
+	var pending, passed, failed int
+
+	for _, check := range checks {
+		switch check.Status {
+		case "COMPLETED":
+			switch check.Conclusion {
+			case "SUCCESS", "NEUTRAL", "SKIPPED":
+				passed++
+			default:
+				failed++
+			}
+		default:
+			pending++
+		}
+	}
+
+	total := len(checks)
+	summary := fmt.Sprintf("Checks: %d/%d completed (%d passed, %d failed, %d pending)",
+		passed+failed, total, passed, failed, pending)
+
+	if pending > 0 {
+		return CheckResultPending, summary
+	}
+	if failed > 0 {
+		return CheckResultFailure, summary
+	}
+	return CheckResultSuccess, summary
+}
+
+func printCheckDetails(checks []CheckStatus) {
+	fmt.Println("\nCheck details:")
+	for _, check := range checks {
+		var status string
+		if check.Status == "COMPLETED" {
+			status = check.Conclusion
+		} else {
+			status = check.Status
+		}
+
+		// Use simple markers for pass/fail
+		marker := " "
+		if check.Conclusion == "SUCCESS" {
+			marker = "+"
+		} else if check.Conclusion == "FAILURE" {
+			marker = "x"
+		}
+
+		fmt.Printf("  [%s] %s: %s\n", marker, check.Name, status)
+	}
+}

--- a/gha_test.go
+++ b/gha_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGha(t *testing.T) {
+	// Save original functions
+	origGhPRView := ghPRViewFn
+	origSleep := sleepFn
+	defer func() {
+		ghPRViewFn = origGhPRView
+		sleepFn = origSleep
+	}()
+
+	t.Run("no PR found", func(t *testing.T) {
+		ghPRViewFn = func() (*PRStatus, error) {
+			return nil, errors.New("no PR found for current branch")
+		}
+
+		err := gha()
+		if err == nil || !strings.Contains(err.Error(), "no PR found") {
+			t.Errorf("gha() error = %v, want error about no PR found", err)
+		}
+	})
+
+	t.Run("all checks pass immediately", func(t *testing.T) {
+		ghPRViewFn = func() (*PRStatus, error) {
+			return &PRStatus{
+				Number: 123,
+				State:  "OPEN",
+				StatusCheckRollup: []CheckStatus{
+					{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+					{Name: "test", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				},
+			}, nil
+		}
+
+		err := gha()
+		if err != nil {
+			t.Errorf("gha() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("check fails", func(t *testing.T) {
+		ghPRViewFn = func() (*PRStatus, error) {
+			return &PRStatus{
+				Number: 123,
+				State:  "OPEN",
+				StatusCheckRollup: []CheckStatus{
+					{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+					{Name: "test", Status: "COMPLETED", Conclusion: "FAILURE"},
+				},
+			}, nil
+		}
+
+		err := gha()
+		if err == nil || !strings.Contains(err.Error(), "checks failed") {
+			t.Errorf("gha() error = %v, want error about checks failed", err)
+		}
+	})
+
+	t.Run("polls until complete", func(t *testing.T) {
+		callCount := 0
+		ghPRViewFn = func() (*PRStatus, error) {
+			callCount++
+			if callCount < 3 {
+				return &PRStatus{
+					Number: 123,
+					State:  "OPEN",
+					StatusCheckRollup: []CheckStatus{
+						{Name: "build", Status: "IN_PROGRESS", Conclusion: ""},
+					},
+				}, nil
+			}
+			return &PRStatus{
+				Number: 123,
+				State:  "OPEN",
+				StatusCheckRollup: []CheckStatus{
+					{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				},
+			}, nil
+		}
+
+		sleepFn = func(d time.Duration) {
+			// Don't actually sleep in tests
+		}
+
+		err := gha()
+		if err != nil {
+			t.Errorf("gha() unexpected error: %v", err)
+		}
+		if callCount != 3 {
+			t.Errorf("gha() called gh %d times, want 3", callCount)
+		}
+	})
+}
+
+func TestAnalyzeChecks(t *testing.T) {
+	tests := []struct {
+		name       string
+		checks     []CheckStatus
+		wantResult CheckResult
+	}{
+		{
+			name:       "empty checks",
+			checks:     []CheckStatus{},
+			wantResult: CheckResultPending,
+		},
+		{
+			name: "all success",
+			checks: []CheckStatus{
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "test", Status: "COMPLETED", Conclusion: "SUCCESS"},
+			},
+			wantResult: CheckResultSuccess,
+		},
+		{
+			name: "one failure",
+			checks: []CheckStatus{
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "test", Status: "COMPLETED", Conclusion: "FAILURE"},
+			},
+			wantResult: CheckResultFailure,
+		},
+		{
+			name: "still pending",
+			checks: []CheckStatus{
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "test", Status: "IN_PROGRESS", Conclusion: ""},
+			},
+			wantResult: CheckResultPending,
+		},
+		{
+			name: "skipped counts as success",
+			checks: []CheckStatus{
+				{Name: "build", Status: "COMPLETED", Conclusion: "SKIPPED"},
+			},
+			wantResult: CheckResultSuccess,
+		},
+		{
+			name: "neutral counts as success",
+			checks: []CheckStatus{
+				{Name: "lint", Status: "COMPLETED", Conclusion: "NEUTRAL"},
+			},
+			wantResult: CheckResultSuccess,
+		},
+		{
+			name: "cancelled counts as failure",
+			checks: []CheckStatus{
+				{Name: "build", Status: "COMPLETED", Conclusion: "CANCELLED"},
+			},
+			wantResult: CheckResultFailure,
+		},
+		{
+			name: "queued status is pending",
+			checks: []CheckStatus{
+				{Name: "build", Status: "QUEUED", Conclusion: ""},
+			},
+			wantResult: CheckResultPending,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, _ := analyzeChecks(tt.checks)
+			if result != tt.wantResult {
+				t.Errorf("analyzeChecks() result = %v, want %v", result, tt.wantResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add new `wt gha` command that monitors GitHub Actions status for the current branch's PR
- Polls `gh pr view` every 30 seconds until all checks complete (success or failure)
- Returns exit code 0 on success, 1 on failure/timeout/no PR found

## Test plan
- [x] Run `go build` to verify compilation
- [x] Run `go test ./...` to verify all tests pass
- [ ] Manual test: Create a PR and run `wt gha` to verify polling behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)