### PR TITLE
Copy .claude/ directory to new worktrees

### DIFF
--- a/create.go
+++ b/create.go
@@ -28,6 +28,16 @@ func create(name, hookPath string) error {
 		return fmt.Errorf("failed to create worktree: %w", err)
 	}
 
+	// Copy .claude/ directory if it exists
+	claudeDir := filepath.Join(root, ".claude")
+	if _, err := os.Stat(claudeDir); err == nil {
+		fmt.Println("Copying .claude/ directory...")
+		dstClaudeDir := filepath.Join(worktreePath, ".claude")
+		if err := copyDir(claudeDir, dstClaudeDir); err != nil {
+			return fmt.Errorf("failed to copy .claude/ directory: %w", err)
+		}
+	}
+
 	// Run hook if it exists
 	hookFullPath := filepath.Join(root, hookPath)
 	if _, err := os.Stat(hookFullPath); err == nil {
@@ -47,4 +57,28 @@ func runHook(hookPath, worktreePath string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		dstPath := filepath.Join(dst, relPath)
+
+		if info.IsDir() {
+			return os.MkdirAll(dstPath, info.Mode())
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(dstPath, data, info.Mode())
+	})
 }


### PR DESCRIPTION
## Summary
- Copies the `.claude/` directory (if present) when creating new worktrees
- Ensures Claude Code permissions persist across worktrees

## Test plan
- [x] Build the tool
- [x] Create a test worktree with `.claude/` present
- [x] Verify `.claude/` was copied to the new worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)