### PR TITLE
Add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ wt
 
 # Coverage
 coverage.out
+
+# Claude
+.claude/


### PR DESCRIPTION
## Summary
- Add `.claude/` directory to `.gitignore` to prevent Claude Code workspace files from being tracked

## Test plan
- [x] Verified `.claude/` is listed in `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)