### PR TITLE
Update Claude GHA workflow to use Opus 4.5

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--model claude-opus-4-5-20251101'
 


### PR DESCRIPTION
## Summary
- Configure claude_args to use `claude-opus-4-5-20251101` model for the Claude Code GitHub Action

## Test plan
- [ ] Verify workflow triggers correctly on @claude mentions
- [ ] Confirm Claude responds using Opus 4.5 model

🤖 Generated with [Claude Code](https://claude.com/claude-code)