### PR TITLE
Use symlink for .claude/ directory instead of copying

### DIFF
--- a/create.go
+++ b/create.go
@@ -7,9 +7,6 @@ import (
 	"path/filepath"
 )
 
-// Function variable for testing
-var filepathRel = filepath.Rel
-
 func create(name, hookPath string) error {
 	// Find git root
 	root, err := gitRoot()
@@ -31,13 +28,13 @@ func create(name, hookPath string) error {
 		return fmt.Errorf("failed to create worktree: %w", err)
 	}
 
-	// Copy .claude/ directory if it exists
+	// Create symlink to .claude/ directory if it exists
 	claudeDir := filepath.Join(root, ".claude")
 	if _, err := os.Stat(claudeDir); err == nil {
-		fmt.Println("Copying .claude/ directory...")
+		fmt.Println("Creating symlink to .claude/ directory...")
 		dstClaudeDir := filepath.Join(worktreePath, ".claude")
-		if err := copyDir(claudeDir, dstClaudeDir); err != nil {
-			return fmt.Errorf("failed to copy .claude/ directory: %w", err)
+		if err := os.Symlink(claudeDir, dstClaudeDir); err != nil {
+			return fmt.Errorf("failed to create .claude/ symlink: %w", err)
 		}
 	}
 
@@ -60,28 +57,4 @@ func runHook(hookPath, worktreePath string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
-}
-
-func copyDir(src, dst string) error {
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		relPath, err := filepathRel(src, path)
-		if err != nil {
-			return err
-		}
-		dstPath := filepath.Join(dst, relPath)
-
-		if info.IsDir() {
-			return os.MkdirAll(dstPath, info.Mode())
-		}
-
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dstPath, data, info.Mode())
-	})
 }

--- a/create_test.go
+++ b/create_test.go
@@ -170,233 +170,16 @@ func TestCreate(t *testing.T) {
 			t.Errorf("create() unexpected error: %v", err)
 		}
 	})
-}
 
-func TestCopyDir(t *testing.T) {
-	t.Run("copies files successfully", func(t *testing.T) {
-		srcDir := t.TempDir()
-		dstDir := filepath.Join(t.TempDir(), "dst")
-
-		// Create a file in source
-		err := os.WriteFile(filepath.Join(srcDir, "file.txt"), []byte("hello"), 0644)
-		if err != nil {
-			t.Fatalf("failed to create source file: %v", err)
-		}
-
-		err = copyDir(srcDir, dstDir)
-		if err != nil {
-			t.Errorf("copyDir() unexpected error: %v", err)
-		}
-
-		// Verify file was copied
-		data, err := os.ReadFile(filepath.Join(dstDir, "file.txt"))
-		if err != nil {
-			t.Errorf("failed to read copied file: %v", err)
-		}
-		if string(data) != "hello" {
-			t.Errorf("copied file content = %q, want %q", string(data), "hello")
-		}
-	})
-
-	t.Run("copies nested directories", func(t *testing.T) {
-		srcDir := t.TempDir()
-		dstDir := filepath.Join(t.TempDir(), "dst")
-
-		// Create nested structure
-		nestedDir := filepath.Join(srcDir, "subdir")
-		os.MkdirAll(nestedDir, 0755)
-		err := os.WriteFile(filepath.Join(nestedDir, "nested.txt"), []byte("nested content"), 0644)
-		if err != nil {
-			t.Fatalf("failed to create nested file: %v", err)
-		}
-
-		err = copyDir(srcDir, dstDir)
-		if err != nil {
-			t.Errorf("copyDir() unexpected error: %v", err)
-		}
-
-		// Verify nested file was copied
-		data, err := os.ReadFile(filepath.Join(dstDir, "subdir", "nested.txt"))
-		if err != nil {
-			t.Errorf("failed to read nested file: %v", err)
-		}
-		if string(data) != "nested content" {
-			t.Errorf("nested file content = %q, want %q", string(data), "nested content")
-		}
-	})
-
-	t.Run("source directory does not exist", func(t *testing.T) {
-		dstDir := filepath.Join(t.TempDir(), "dst")
-		err := copyDir("/nonexistent/path", dstDir)
-		if err == nil {
-			t.Error("copyDir() expected error for non-existent source")
-		}
-	})
-
-	t.Run("empty source directory", func(t *testing.T) {
-		srcDir := t.TempDir()
-		dstDir := filepath.Join(t.TempDir(), "dst")
-
-		err := copyDir(srcDir, dstDir)
-		if err != nil {
-			t.Errorf("copyDir() unexpected error: %v", err)
-		}
-
-		// Verify destination was created
-		info, err := os.Stat(dstDir)
-		if err != nil {
-			t.Errorf("destination directory was not created: %v", err)
-		}
-		if !info.IsDir() {
-			t.Error("destination is not a directory")
-		}
-	})
-
-	t.Run("unreadable file in source", func(t *testing.T) {
-		srcDir := t.TempDir()
-		dstDir := filepath.Join(t.TempDir(), "dst")
-
-		// Create a file and make it unreadable
-		filePath := filepath.Join(srcDir, "unreadable.txt")
-		err := os.WriteFile(filePath, []byte("secret"), 0000)
-		if err != nil {
-			t.Fatalf("failed to create file: %v", err)
-		}
-		defer os.Chmod(filePath, 0644) // Restore for cleanup
-
-		err = copyDir(srcDir, dstDir)
-		if err == nil {
-			t.Error("copyDir() expected error for unreadable file")
-		}
-	})
-
-	t.Run("filepath.Rel error", func(t *testing.T) {
-		// Save original function
-		origFilepathRel := filepathRel
-		defer func() { filepathRel = origFilepathRel }()
-
-		srcDir := t.TempDir()
-		dstDir := filepath.Join(t.TempDir(), "dst")
-
-		// Create a file in source
-		err := os.WriteFile(filepath.Join(srcDir, "file.txt"), []byte("hello"), 0644)
-		if err != nil {
-			t.Fatalf("failed to create source file: %v", err)
-		}
-
-		// Mock filepathRel to return an error
-		filepathRel = func(basepath, targpath string) (string, error) {
-			return "", errors.New("cannot make path relative")
-		}
-
-		err = copyDir(srcDir, dstDir)
-		if err == nil || !strings.Contains(err.Error(), "cannot make path relative") {
-			t.Errorf("copyDir() error = %v, want error about cannot make path relative", err)
-		}
-	})
-}
-
-func TestCreateWithClaudeDir(t *testing.T) {
-	// Save original functions and restore after test
-	origGitRoot := gitRootFn
-	origGitCmd := gitCmdFn
-	defer func() {
-		gitRootFn = origGitRoot
-		gitCmdFn = origGitCmd
-	}()
-
-	t.Run("copies .claude directory", func(t *testing.T) {
+	t.Run("creates symlink to .claude directory", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		worktreesDir := filepath.Join(tmpDir, ".worktrees")
 		os.MkdirAll(worktreesDir, 0755)
 
-		// Create .claude directory with content
+		// Create .claude directory with a file
 		claudeDir := filepath.Join(tmpDir, ".claude")
 		os.MkdirAll(claudeDir, 0755)
-		err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{"key": "value"}`), 0644)
-		if err != nil {
-			t.Fatalf("failed to create claude settings: %v", err)
-		}
-
-		worktreePath := filepath.Join(worktreesDir, "test-branch")
-
-		gitRootFn = func() (string, error) {
-			return tmpDir, nil
-		}
-		gitCmdFn = func(dir string, args ...string) error {
-			if len(args) > 0 && args[0] == "worktree" {
-				os.MkdirAll(worktreePath, 0755)
-			}
-			return nil
-		}
-
-		err = create("test-branch", ".worktree-hook")
-		if err != nil {
-			t.Errorf("create() unexpected error: %v", err)
-		}
-
-		// Verify .claude directory was copied
-		data, err := os.ReadFile(filepath.Join(worktreePath, ".claude", "settings.json"))
-		if err != nil {
-			t.Errorf("failed to read copied claude settings: %v", err)
-		}
-		if string(data) != `{"key": "value"}` {
-			t.Errorf("copied settings content = %q, want %q", string(data), `{"key": "value"}`)
-		}
-	})
-
-	t.Run("copies .claude directory with hook", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		worktreesDir := filepath.Join(tmpDir, ".worktrees")
-		os.MkdirAll(worktreesDir, 0755)
-
-		// Create .claude directory
-		claudeDir := filepath.Join(tmpDir, ".claude")
-		os.MkdirAll(claudeDir, 0755)
-		os.WriteFile(filepath.Join(claudeDir, "config.txt"), []byte("config"), 0644)
-
-		// Create hook
-		hookPath := filepath.Join(tmpDir, ".worktree-hook")
-		err := os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 0\n"), 0755)
-		if err != nil {
-			t.Fatalf("failed to create hook: %v", err)
-		}
-
-		worktreePath := filepath.Join(worktreesDir, "test-branch")
-
-		gitRootFn = func() (string, error) {
-			return tmpDir, nil
-		}
-		gitCmdFn = func(dir string, args ...string) error {
-			if len(args) > 0 && args[0] == "worktree" {
-				os.MkdirAll(worktreePath, 0755)
-			}
-			return nil
-		}
-
-		err = create("test-branch", ".worktree-hook")
-		if err != nil {
-			t.Errorf("create() unexpected error: %v", err)
-		}
-
-		// Verify .claude directory was copied
-		_, err = os.Stat(filepath.Join(worktreePath, ".claude", "config.txt"))
-		if err != nil {
-			t.Errorf(".claude directory was not copied: %v", err)
-		}
-	})
-
-	t.Run("copyDir failure is handled", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		worktreesDir := filepath.Join(tmpDir, ".worktrees")
-		os.MkdirAll(worktreesDir, 0755)
-
-		// Create .claude directory with unreadable file
-		claudeDir := filepath.Join(tmpDir, ".claude")
-		os.MkdirAll(claudeDir, 0755)
-		unreadablePath := filepath.Join(claudeDir, "unreadable.txt")
-		os.WriteFile(unreadablePath, []byte("secret"), 0000)
-		defer os.Chmod(unreadablePath, 0644)
+		os.WriteFile(filepath.Join(claudeDir, "test.md"), []byte("test content"), 0644)
 
 		worktreePath := filepath.Join(worktreesDir, "test-branch")
 
@@ -411,8 +194,56 @@ func TestCreateWithClaudeDir(t *testing.T) {
 		}
 
 		err := create("test-branch", ".worktree-hook")
-		if err == nil || !strings.Contains(err.Error(), "failed to copy .claude/ directory") {
-			t.Errorf("create() error = %v, want error about failed to copy .claude/ directory", err)
+		if err != nil {
+			t.Errorf("create() unexpected error: %v", err)
+		}
+
+		// Verify symlink was created
+		symlinkPath := filepath.Join(worktreePath, ".claude")
+		info, err := os.Lstat(symlinkPath)
+		if err != nil {
+			t.Fatalf("failed to stat symlink: %v", err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Error("expected .claude to be a symlink")
+		}
+
+		// Verify symlink points to correct location
+		target, err := os.Readlink(symlinkPath)
+		if err != nil {
+			t.Fatalf("failed to read symlink: %v", err)
+		}
+		if target != claudeDir {
+			t.Errorf("symlink target = %v, want %v", target, claudeDir)
+		}
+	})
+
+	t.Run("symlink creation fails", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		worktreesDir := filepath.Join(tmpDir, ".worktrees")
+		os.MkdirAll(worktreesDir, 0755)
+
+		// Create .claude directory
+		claudeDir := filepath.Join(tmpDir, ".claude")
+		os.MkdirAll(claudeDir, 0755)
+
+		worktreePath := filepath.Join(worktreesDir, "test-branch")
+
+		gitRootFn = func() (string, error) {
+			return tmpDir, nil
+		}
+		gitCmdFn = func(dir string, args ...string) error {
+			if len(args) > 0 && args[0] == "worktree" {
+				os.MkdirAll(worktreePath, 0755)
+				// Create a file at .claude path to make symlink fail
+				os.WriteFile(filepath.Join(worktreePath, ".claude"), []byte("block"), 0644)
+			}
+			return nil
+		}
+
+		err := create("test-branch", ".worktree-hook")
+		if err == nil || !strings.Contains(err.Error(), "failed to create .claude/ symlink") {
+			t.Errorf("create() error = %v, want error about failed to create symlink", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Create a symlink to `.claude/` directory in the root repo instead of copying it to new worktrees
- This avoids needing to merge changes back when the `.claude/` directory is modified
- Fixed git tests that were corrupting the repo (`core.bare = true`) when running in pre-commit hooks by replacing `os.Chdir()` with `t.Setenv("GIT_DIR", ...)`

## Test plan
- [x] Tests pass with 100% coverage
- [x] Verified running tests no longer corrupts the repo
- [ ] Create a new worktree and verify `.claude/` is a symlink pointing to root repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)