### PR TITLE
Fix shell wrappers swallowing completion output

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,17 @@ Alternatively, copy the wrapper function directly into your shell config:
 ```bash
 wt() {
     local wt_bin
-    wt_bin=$(command -v wt 2>/dev/null)
+    wt_bin=$(type -P wt 2>/dev/null)
     if [[ -z "$wt_bin" ]]; then
         echo "error: wt binary not found in PATH" >&2
         return 1
     fi
+    case "$1" in
+        completion|__complete)
+            "$wt_bin" "$@"
+            return $?
+            ;;
+    esac
     local dir
     dir=$("$wt_bin" "$@")
     local exit_code=$?
@@ -76,6 +82,13 @@ function wt --description "Git worktree manager with auto-cd"
     if test -z "$wt_bin"
         echo "error: wt binary not found in PATH" >&2
         return 1
+    end
+    if test (count $argv) -gt 0
+        switch $argv[1]
+            case completion __complete
+                $wt_bin $argv
+                return $status
+        end
     end
     set -l dir ($wt_bin $argv)
     set -l exit_code $status

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildWtBinary builds the wt binary to a temp directory and returns the path.
+func buildWtBinary(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	binPath := filepath.Join(tmpDir, "wt")
+
+	cmd := exec.Command("go", "build", "-o", binPath, ".")
+	cmd.Dir = "."
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build wt binary: %v\n%s", err, output)
+	}
+	return binPath
+}
+
+func TestBashWrapperCompletionPassthrough(t *testing.T) {
+	binPath := buildWtBinary(t)
+
+	// Write wrapper script to temp file
+	wrapperContent, err := os.ReadFile("wt.sh")
+	if err != nil {
+		t.Fatalf("failed to read wt.sh: %v", err)
+	}
+	wrapperPath := filepath.Join(t.TempDir(), "wt.sh")
+	if err := os.WriteFile(wrapperPath, wrapperContent, 0644); err != nil {
+		t.Fatalf("failed to write wrapper: %v", err)
+	}
+
+	// Execute via bash, setting PATH to include our binary
+	binDir := filepath.Dir(binPath)
+	script := "export PATH=" + binDir + ":$PATH && source " + wrapperPath + " && wt completion bash"
+	cmd := exec.Command("bash", "-c", script)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("wt completion bash failed: %v\n%s", err, output)
+	}
+
+	// Verify completion script content is present
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "_wt_completions") {
+		t.Errorf("bash wrapper did not pass through completion output.\nGot: %s", outputStr)
+	}
+	if !strings.Contains(outputStr, "complete -F _wt_completions wt") {
+		t.Errorf("bash wrapper missing complete command in output.\nGot: %s", outputStr)
+	}
+}
+
+func TestBashWrapperCompletePassthrough(t *testing.T) {
+	binPath := buildWtBinary(t)
+
+	// Write wrapper script to temp file
+	wrapperContent, err := os.ReadFile("wt.sh")
+	if err != nil {
+		t.Fatalf("failed to read wt.sh: %v", err)
+	}
+	wrapperPath := filepath.Join(t.TempDir(), "wt.sh")
+	if err := os.WriteFile(wrapperPath, wrapperContent, 0644); err != nil {
+		t.Fatalf("failed to write wrapper: %v", err)
+	}
+
+	// Execute via bash, setting PATH to include our binary
+	binDir := filepath.Dir(binPath)
+	script := "export PATH=" + binDir + ":$PATH && source " + wrapperPath + " && wt __complete remove"
+	cmd := exec.Command("bash", "-c", script)
+
+	// __complete may return empty or worktree names, but should not error
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("wt __complete remove failed: %v\n%s", err, output)
+	}
+	// Success - command executed without the wrapper swallowing output
+}
+
+func TestFishWrapperCompletionPassthrough(t *testing.T) {
+	// Skip if fish is not installed
+	if _, err := exec.LookPath("fish"); err != nil {
+		t.Skip("fish shell not installed, skipping test")
+	}
+
+	binPath := buildWtBinary(t)
+
+	// Write wrapper script to temp file
+	wrapperContent, err := os.ReadFile("wt.fish")
+	if err != nil {
+		t.Fatalf("failed to read wt.fish: %v", err)
+	}
+	wrapperPath := filepath.Join(t.TempDir(), "wt.fish")
+	if err := os.WriteFile(wrapperPath, wrapperContent, 0644); err != nil {
+		t.Fatalf("failed to write wrapper: %v", err)
+	}
+
+	// Execute via fish, setting PATH to include our binary
+	binDir := filepath.Dir(binPath)
+	script := "set -x PATH " + binDir + " $PATH; source " + wrapperPath + "; and wt completion fish"
+	cmd := exec.Command("fish", "-c", script)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("wt completion fish failed: %v\n%s", err, output)
+	}
+
+	// Verify completion script content is present
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "__wt_worktrees") {
+		t.Errorf("fish wrapper did not pass through completion output.\nGot: %s", outputStr)
+	}
+	if !strings.Contains(outputStr, "complete -c wt") {
+		t.Errorf("fish wrapper missing complete command in output.\nGot: %s", outputStr)
+	}
+}
+
+func TestFishWrapperCompletePassthrough(t *testing.T) {
+	// Skip if fish is not installed
+	if _, err := exec.LookPath("fish"); err != nil {
+		t.Skip("fish shell not installed, skipping test")
+	}
+
+	binPath := buildWtBinary(t)
+
+	// Write wrapper script to temp file
+	wrapperContent, err := os.ReadFile("wt.fish")
+	if err != nil {
+		t.Fatalf("failed to read wt.fish: %v", err)
+	}
+	wrapperPath := filepath.Join(t.TempDir(), "wt.fish")
+	if err := os.WriteFile(wrapperPath, wrapperContent, 0644); err != nil {
+		t.Fatalf("failed to write wrapper: %v", err)
+	}
+
+	// Execute via fish, setting PATH to include our binary
+	binDir := filepath.Dir(binPath)
+	script := "set -x PATH " + binDir + " $PATH; source " + wrapperPath + "; and wt __complete remove"
+	cmd := exec.Command("fish", "-c", script)
+
+	// __complete may return empty or worktree names, but should not error
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("wt __complete remove failed: %v\n%s", err, output)
+	}
+	// Success - command executed without the wrapper swallowing output
+}

--- a/wt.fish
+++ b/wt.fish
@@ -14,6 +14,15 @@ function wt --description "Git worktree manager with auto-cd"
         return 1
     end
 
+    # Pass through commands that produce non-directory output
+    if test (count $argv) -gt 0
+        switch $argv[1]
+            case completion __complete
+                $wt_bin $argv
+                return $status
+        end
+    end
+
     # Run wt and capture stdout (the directory path)
     set -l dir ($wt_bin $argv)
     set -l exit_code $status

--- a/wt.sh
+++ b/wt.sh
@@ -8,13 +8,21 @@
 #   source /path/to/wt.sh
 
 wt() {
-    # Find the real wt binary
+    # Find the real wt binary (use type -P to bypass the function)
     local wt_bin
-    wt_bin=$(command -v wt 2>/dev/null)
+    wt_bin=$(type -P wt 2>/dev/null)
     if [[ -z "$wt_bin" ]]; then
         echo "error: wt binary not found in PATH" >&2
         return 1
     fi
+
+    # Pass through commands that produce non-directory output
+    case "$1" in
+        completion|__complete)
+            "$wt_bin" "$@"
+            return $?
+            ;;
+    esac
 
     # Run wt and capture stdout (the directory path)
     local dir


### PR DESCRIPTION
## Summary
- Fix shell wrappers (`wt.sh`, `wt.fish`) capturing stdout for completion commands
- Add pass-through for `completion` and `__complete` commands so output is not swallowed
- Fix bash wrapper using `type -P wt` instead of `command -v wt` to find the binary (not the function)

## Problem
Running `wt completion fish > ~/.config/fish/completions/wt.fish` created an empty file because the wrapper captured stdout to check if it was a directory path for auto-cd.

## Test plan
- [x] All existing tests pass
- [x] New integration tests in `wrapper_test.go` verify completion passthrough for bash and fish
- [x] 100% test coverage maintained
- [x] Manual verification: `./wt completion fish` outputs the completion script

🤖 Generated with [Claude Code](https://claude.ai/claude-code)