### PR TITLE
Add wt list command for worktr

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ wt <command> [options] [args]
 | `jump` | Jump to a worktree or repository root |
 | `create` | Create a new worktree with branch |
 | `remove` | Remove a worktree and its branch (auto-detects if inside worktree) |
+| `list` | List all worktrees |
 | `gha` | Monitor GitHub Actions status for current branch's PR |
 | `completion` | Generate shell completion script (bash, zsh, fish) |
 
@@ -136,6 +137,7 @@ wt create my-feature       # Create worktree for 'my-feature' branch
 wt create --hook setup.sh feat    # Create worktree, run setup.sh as hook
 wt remove my-feature       # Remove worktree and branch
 wt remove                  # Remove current worktree (when inside one)
+wt list                    # List all worktrees
 wt gha                     # Monitor GitHub Actions for current branch's PR
 wt completion bash         # Generate bash completion script
 ```

--- a/completion.go
+++ b/completion.go
@@ -57,7 +57,7 @@ func bashCompletion(w io.Writer) error {
     local cur prev words cword
     _init_completion || return
 
-    local commands="jump create remove gha completion"
+    local commands="jump create remove list gha completion"
 
     case "${prev}" in
         wt)
@@ -120,6 +120,7 @@ _wt() {
         'jump:Jump to a worktree or repo root'
         'create:Create a new worktree with branch'
         'remove:Remove a worktree and its branch'
+        'list:List all worktrees'
         'gha:Monitor GitHub Actions status for current branch PR'
         'completion:Generate shell completion script'
     )
@@ -176,6 +177,7 @@ complete -c wt -f
 complete -c wt -n "__fish_use_subcommand" -a "jump" -d "Jump to a worktree or repo root"
 complete -c wt -n "__fish_use_subcommand" -a "create" -d "Create a new worktree with branch"
 complete -c wt -n "__fish_use_subcommand" -a "remove" -d "Remove a worktree and its branch"
+complete -c wt -n "__fish_use_subcommand" -a "list" -d "List all worktrees"
 complete -c wt -n "__fish_use_subcommand" -a "gha" -d "Monitor GitHub Actions status"
 complete -c wt -n "__fish_use_subcommand" -a "completion" -d "Generate shell completion script"
 

--- a/list.go
+++ b/list.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+// list outputs all worktree names, one per line.
+func list(w io.Writer) error {
+	worktrees, err := listWorktrees()
+	if err != nil {
+		return err
+	}
+	for _, wt := range worktrees {
+		fmt.Fprintln(w, wt)
+	}
+	return nil
+}

--- a/list_test.go
+++ b/list_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestList(t *testing.T) {
+	// Save original function and restore after test
+	origListWorktrees := listWorktreesFn
+	defer func() {
+		listWorktreesFn = origListWorktrees
+	}()
+
+	t.Run("success with worktrees", func(t *testing.T) {
+		listWorktreesFn = func() ([]string, error) {
+			return []string{"feature-a", "feature-b", "bugfix-c"}, nil
+		}
+
+		var buf bytes.Buffer
+		err := list(&buf)
+		if err != nil {
+			t.Errorf("list() unexpected error: %v", err)
+		}
+
+		output := buf.String()
+		lines := strings.Split(strings.TrimSpace(output), "\n")
+		if len(lines) != 3 {
+			t.Errorf("list() output %d lines, want 3", len(lines))
+		}
+		expected := map[string]bool{"feature-a": true, "feature-b": true, "bugfix-c": true}
+		for _, line := range lines {
+			if !expected[line] {
+				t.Errorf("list() unexpected line: %q", line)
+			}
+		}
+	})
+
+	t.Run("success with no worktrees", func(t *testing.T) {
+		listWorktreesFn = func() ([]string, error) {
+			return []string{}, nil
+		}
+
+		var buf bytes.Buffer
+		err := list(&buf)
+		if err != nil {
+			t.Errorf("list() unexpected error: %v", err)
+		}
+		if buf.Len() != 0 {
+			t.Errorf("list() wrote output for empty list: %q", buf.String())
+		}
+	})
+
+	t.Run("error from listWorktrees", func(t *testing.T) {
+		listWorktreesFn = func() ([]string, error) {
+			return nil, errors.New("not in a git repository")
+		}
+
+		var buf bytes.Buffer
+		err := list(&buf)
+		if err == nil || err.Error() != "not in a git repository" {
+			t.Errorf("list() error = %v, want 'not in a git repository'", err)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ var errShowHelp = errors.New("show help")
 var exitFn = os.Exit
 
 // validCommands lists all valid command names
-var validCommands = []string{"create", "remove", "jump", "gha", "completion", "__complete"}
+var validCommands = []string{"create", "remove", "jump", "list", "gha", "completion", "__complete"}
 
 func usageText() string {
 	return `Usage: wt <command> [options] [args]
@@ -23,6 +23,7 @@ Commands:
   jump          Jump to a worktree or repository root
   create        Create a new worktree with branch
   remove        Remove a worktree and its branch (auto-detects if inside worktree)
+  list          List all worktrees
   gha           Monitor GitHub Actions status for current branch's PR
   completion    Generate shell completion script (bash, zsh, fish)
 
@@ -37,6 +38,7 @@ Examples:
   wt create --hook setup.sh feat    Create worktree, run setup.sh as hook
   wt remove my-feature       Remove worktree and branch
   wt remove                  Remove current worktree (when inside one)
+  wt list                    List all worktrees
   wt gha                     Wait for GHA checks on current branch's PR
   wt completion bash         Generate bash completion script
 `
@@ -139,6 +141,14 @@ func parseArgs(args []string) (cmd string, name string, hookPath string, err err
 		return cmd, "", hookPath, nil
 	}
 
+	// list command takes no additional arguments
+	if cmd == "list" {
+		if idx < len(args) {
+			return "", "", "", fmt.Errorf("unexpected argument: %s", args[idx])
+		}
+		return cmd, "", hookPath, nil
+	}
+
 	// completion command takes a shell name
 	if cmd == "completion" {
 		if idx >= len(args) {
@@ -210,6 +220,8 @@ func run(args []string) error {
 		return create(name, hookPath)
 	case "remove":
 		return runRemove(name)
+	case "list":
+		return list(os.Stdout)
 	case "gha":
 		return gha()
 	case "completion":

--- a/main_test.go
+++ b/main_test.go
@@ -55,6 +55,7 @@ func TestIsValidCommand(t *testing.T) {
 		{"create", "create", true},
 		{"remove", "remove", true},
 		{"jump", "jump", true},
+		{"list", "list", true},
 		{"gha", "gha", true},
 		{"completion", "completion", true},
 		{"__complete", "__complete", true},
@@ -322,6 +323,18 @@ func TestParseArgs(t *testing.T) {
 			wantErrMsg: "unexpected argument: extra",
 		},
 		{
+			name:     "list command no args",
+			args:     []string{"list"},
+			wantCmd:  "list",
+			wantName: "",
+			wantHook: DefaultHook,
+		},
+		{
+			name:       "list command with extra arg",
+			args:       []string{"list", "extra"},
+			wantErrMsg: "unexpected argument: extra",
+		},
+		{
 			name:     "completion command bash",
 			args:     []string{"completion", "bash"},
 			wantCmd:  "completion",
@@ -555,6 +568,34 @@ func TestRun(t *testing.T) {
 		err := run([]string{"gha"})
 		if err == nil || err.Error() != "mock: no PR found for current branch" {
 			t.Errorf("run() error = %v, want 'mock: no PR found for current branch'", err)
+		}
+	})
+
+	t.Run("list command calls list", func(t *testing.T) {
+		origListWorktrees := listWorktreesFn
+		defer func() { listWorktreesFn = origListWorktrees }()
+
+		listWorktreesFn = func() ([]string, error) {
+			return []string{"feature-a", "feature-b"}, nil
+		}
+
+		err := run([]string{"list"})
+		if err != nil {
+			t.Errorf("run() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("list command with error", func(t *testing.T) {
+		origListWorktrees := listWorktreesFn
+		defer func() { listWorktreesFn = origListWorktrees }()
+
+		listWorktreesFn = func() ([]string, error) {
+			return nil, errors.New("mock: not in git repo")
+		}
+
+		err := run([]string{"list"})
+		if err == nil || err.Error() != "mock: not in git repo" {
+			t.Errorf("run() error = %v, want 'mock: not in git repo'", err)
 		}
 	})
 


### PR DESCRIPTION
Add a new `wt list` command that outputs all worktree names, one per line. This provides a simple way to see all available worktrees without needing to look at the .worktrees directory directly.