### PR TITLE
Fix wt list command functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ wt() {
         return 1
     fi
     case "$1" in
-        completion|__complete|"")
+        completion|__complete|list|version|"")
             "$wt_bin" "$@"
             return $?
             ;;
@@ -90,7 +90,7 @@ function wt --description "Git worktree manager with auto-cd"
         return $status
     end
     switch $argv[1]
-        case completion __complete
+        case completion __complete list version
             $wt_bin $argv
             return $status
     end

--- a/wt.fish
+++ b/wt.fish
@@ -21,7 +21,7 @@ function wt --description "Git worktree manager with auto-cd"
     end
 
     switch $argv[1]
-        case completion __complete
+        case completion __complete list version
             $wt_bin $argv
             return $status
     end

--- a/wt.sh
+++ b/wt.sh
@@ -18,7 +18,7 @@ wt() {
 
     # Pass through commands that produce non-directory output
     case "$1" in
-        completion|__complete|"")
+        completion|__complete|list|version|"")
             "$wt_bin" "$@"
             return $?
             ;;


### PR DESCRIPTION
The shell wrappers capture stdout expecting a directory path for cd, but list and version commands output text that should be displayed directly. Add these commands to the pass-through case alongside completion.